### PR TITLE
tests: standardize naming of events

### DIFF
--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -828,15 +828,15 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 	expect_pending_htlcs_forwardable_and_htlc_handling_failed!(nodes[2], vec![HTLCHandlingFailureType::Receive { payment_hash: payment_hash_1 }]);
 	check_added_monitors!(nodes[2], 1);
 
-	let updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
-	assert!(updates.update_add_htlcs.is_empty());
-	assert!(updates.update_fulfill_htlcs.is_empty());
-	assert_eq!(updates.update_fail_htlcs.len(), 1);
-	assert!(updates.update_fail_malformed_htlcs.is_empty());
-	assert!(updates.update_fee.is_none());
-	nodes[1].node.handle_update_fail_htlc(nodes[2].node.get_our_node_id(), &updates.update_fail_htlcs[0]);
+	let cs_updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+	assert!(cs_updates.update_add_htlcs.is_empty());
+	assert!(cs_updates.update_fulfill_htlcs.is_empty());
+	assert_eq!(cs_updates.update_fail_htlcs.len(), 1);
+	assert!(cs_updates.update_fail_malformed_htlcs.is_empty());
+	assert!(cs_updates.update_fee.is_none());
+	nodes[1].node.handle_update_fail_htlc(nodes[2].node.get_our_node_id(), &cs_updates.update_fail_htlcs[0]);
 
-	let bs_revoke_and_ack = commitment_signed_dance!(nodes[1], nodes[2], updates.commitment_signed, false, true, false, true);
+	let cs_revoke_and_ack = commitment_signed_dance!(nodes[1], nodes[2], cs_updates.commitment_signed, false, true, false, true);
 	check_added_monitors!(nodes[0], 0);
 
 	// While the second channel is AwaitingRAA, forward a second payment to get it into the
@@ -858,7 +858,7 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 
 	// Now fail monitor updating.
 	chanmon_cfgs[1].persister.set_update_ret(ChannelMonitorUpdateStatus::InProgress);
-	nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &bs_revoke_and_ack);
+	nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &cs_revoke_and_ack);
 	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
 	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
 	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
@@ -954,34 +954,34 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 	expect_payment_failed!(nodes[0], payment_hash_1, true);
 
 	nodes[2].node.handle_update_add_htlc(nodes[1].node.get_our_node_id(), &send_event_b.msgs[0]);
-	let as_cs;
+	let bs_updates;
 	if test_ignore_second_cs {
 		nodes[2].node.handle_commitment_signed_batch_test(nodes[1].node.get_our_node_id(), &send_event_b.commitment_msg);
 		check_added_monitors!(nodes[2], 1);
-		let bs_revoke_and_ack = get_event_msg!(nodes[2], MessageSendEvent::SendRevokeAndACK, nodes[1].node.get_our_node_id());
+		let cs_revoke_and_ack = get_event_msg!(nodes[2], MessageSendEvent::SendRevokeAndACK, nodes[1].node.get_our_node_id()); // TODO
 		nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &raa.unwrap());
 		check_added_monitors!(nodes[2], 1);
-		let bs_cs = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
-		assert!(bs_cs.update_add_htlcs.is_empty());
-		assert!(bs_cs.update_fail_htlcs.is_empty());
-		assert!(bs_cs.update_fail_malformed_htlcs.is_empty());
-		assert!(bs_cs.update_fulfill_htlcs.is_empty());
-		assert!(bs_cs.update_fee.is_none());
+		let cs_updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+		assert!(cs_updates.update_add_htlcs.is_empty());
+		assert!(cs_updates.update_fail_htlcs.is_empty());
+		assert!(cs_updates.update_fail_malformed_htlcs.is_empty());
+		assert!(cs_updates.update_fulfill_htlcs.is_empty());
+		assert!(cs_updates.update_fee.is_none());
 
-		nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &bs_revoke_and_ack);
+		nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &cs_revoke_and_ack);
 		check_added_monitors!(nodes[1], 1);
-		as_cs = get_htlc_update_msgs!(nodes[1], nodes[2].node.get_our_node_id());
+		bs_updates = get_htlc_update_msgs!(nodes[1], nodes[2].node.get_our_node_id());
 
-		nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &bs_cs.commitment_signed);
+		nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &cs_updates.commitment_signed);
 		check_added_monitors!(nodes[1], 1);
 	} else {
 		nodes[2].node.handle_commitment_signed_batch_test(nodes[1].node.get_our_node_id(), &send_event_b.commitment_msg);
 		check_added_monitors!(nodes[2], 1);
 
-		let bs_revoke_and_commit = nodes[2].node.get_and_clear_pending_msg_events();
+		let cs_revoke_and_commit = nodes[2].node.get_and_clear_pending_msg_events();
 		// As both messages are for nodes[1], they're in order.
-		assert_eq!(bs_revoke_and_commit.len(), 2);
-		match bs_revoke_and_commit[0] {
+		assert_eq!(cs_revoke_and_commit.len(), 2);
+		match cs_revoke_and_commit[0] {
 			MessageSendEvent::SendRevokeAndACK { ref node_id, ref msg } => {
 				assert_eq!(*node_id, nodes[1].node.get_our_node_id());
 				nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &msg);
@@ -990,9 +990,9 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 			_ => panic!("Unexpected event"),
 		}
 
-		as_cs = get_htlc_update_msgs!(nodes[1], nodes[2].node.get_our_node_id());
+		bs_updates = get_htlc_update_msgs!(nodes[1], nodes[2].node.get_our_node_id());
 
-		match bs_revoke_and_commit[1] {
+		match cs_revoke_and_commit[1] {
 			MessageSendEvent::UpdateHTLCs { ref node_id, channel_id: _, ref updates } => {
 				assert_eq!(*node_id, nodes[1].node.get_our_node_id());
 				assert!(updates.update_add_htlcs.is_empty());
@@ -1007,32 +1007,32 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 		}
 	}
 
-	assert_eq!(as_cs.update_add_htlcs.len(), 1);
-	assert!(as_cs.update_fail_htlcs.is_empty());
-	assert!(as_cs.update_fail_malformed_htlcs.is_empty());
-	assert!(as_cs.update_fulfill_htlcs.is_empty());
-	assert!(as_cs.update_fee.is_none());
-	let as_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
+	assert_eq!(bs_updates.update_add_htlcs.len(), 1);
+	assert!(bs_updates.update_fail_htlcs.is_empty());
+	assert!(bs_updates.update_fail_malformed_htlcs.is_empty());
+	assert!(bs_updates.update_fulfill_htlcs.is_empty());
+	assert!(bs_updates.update_fee.is_none());
+	let bs_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
 
 
-	nodes[2].node.handle_update_add_htlc(nodes[1].node.get_our_node_id(), &as_cs.update_add_htlcs[0]);
-	nodes[2].node.handle_commitment_signed_batch_test(nodes[1].node.get_our_node_id(), &as_cs.commitment_signed);
+	nodes[2].node.handle_update_add_htlc(nodes[1].node.get_our_node_id(), &bs_updates.update_add_htlcs[0]);
+	nodes[2].node.handle_commitment_signed_batch_test(nodes[1].node.get_our_node_id(), &bs_updates.commitment_signed);
 	check_added_monitors!(nodes[2], 1);
-	let bs_second_raa = get_event_msg!(nodes[2], MessageSendEvent::SendRevokeAndACK, nodes[1].node.get_our_node_id());
+	let cs_second_raa = get_event_msg!(nodes[2], MessageSendEvent::SendRevokeAndACK, nodes[1].node.get_our_node_id());
 
-	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &as_raa);
+	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &bs_raa);
 	check_added_monitors!(nodes[2], 1);
-	let bs_second_cs = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+	let cs_second_update = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
 
-	nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &bs_second_raa);
+	nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &cs_second_raa);
 	check_added_monitors!(nodes[1], 1);
 	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
 
-	nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &bs_second_cs.commitment_signed);
+	nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &cs_second_update.commitment_signed);
 	check_added_monitors!(nodes[1], 1);
-	let as_second_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
+	let bs_second_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
 
-	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &as_second_raa);
+	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &bs_second_raa);
 	check_added_monitors!(nodes[2], 1);
 	assert!(nodes[2].node.get_and_clear_pending_msg_events().is_empty());
 

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1543,10 +1543,10 @@ pub fn create_unannounced_chan_between_nodes_with_value<'a, 'b, 'c, 'd>(nodes: &
 	nodes[b].node.handle_funding_created(nodes[a].node.get_our_node_id(), &get_event_msg!(nodes[a], MessageSendEvent::SendFundingCreated, nodes[b].node.get_our_node_id()));
 	check_added_monitors!(nodes[b], 1);
 
-	let cs_funding_signed = get_event_msg!(nodes[b], MessageSendEvent::SendFundingSigned, nodes[a].node.get_our_node_id());
+	let bs_funding_signed = get_event_msg!(nodes[b], MessageSendEvent::SendFundingSigned, nodes[a].node.get_our_node_id());
 	expect_channel_pending_event(&nodes[b], &nodes[a].node.get_our_node_id());
 
-	nodes[a].node.handle_funding_signed(nodes[b].node.get_our_node_id(), &cs_funding_signed);
+	nodes[a].node.handle_funding_signed(nodes[b].node.get_our_node_id(), &bs_funding_signed);
 	expect_channel_pending_event(&nodes[a], &nodes[b].node.get_our_node_id());
 	check_added_monitors!(nodes[a], 1);
 

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -1292,31 +1292,31 @@ pub fn holding_cell_htlc_counting() {
 	nodes[2].node.handle_commitment_signed_batch_test(nodes[1].node.get_our_node_id(), &initial_payment_event.commitment_msg);
 	check_added_monitors!(nodes[2], 1);
 
-	let (bs_revoke_and_ack, bs_commitment_signed) = get_revoke_commit_msgs!(nodes[2], nodes[1].node.get_our_node_id());
-	nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &bs_revoke_and_ack);
+	let (cs_revoke_and_ack, cs_commitment_signed) = get_revoke_commit_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+	nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &cs_revoke_and_ack);
 	check_added_monitors!(nodes[1], 1);
-	let as_updates = get_htlc_update_msgs!(nodes[1], nodes[2].node.get_our_node_id());
+	let bs_updates = get_htlc_update_msgs!(nodes[1], nodes[2].node.get_our_node_id());
 
-	nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &bs_commitment_signed);
+	nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &cs_commitment_signed);
 	check_added_monitors!(nodes[1], 1);
-	let as_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
+	let bs_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
 
-	for ref update in as_updates.update_add_htlcs.iter() {
+	for ref update in bs_updates.update_add_htlcs.iter() {
 		nodes[2].node.handle_update_add_htlc(nodes[1].node.get_our_node_id(), update);
 	}
-	nodes[2].node.handle_commitment_signed_batch_test(nodes[1].node.get_our_node_id(), &as_updates.commitment_signed);
+	nodes[2].node.handle_commitment_signed_batch_test(nodes[1].node.get_our_node_id(), &bs_updates.commitment_signed);
 	check_added_monitors!(nodes[2], 1);
-	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &as_raa);
+	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &bs_raa);
 	check_added_monitors!(nodes[2], 1);
-	let (bs_revoke_and_ack, bs_commitment_signed) = get_revoke_commit_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+	let (cs_revoke_and_ack, cs_commitment_signed) = get_revoke_commit_msgs!(nodes[2], nodes[1].node.get_our_node_id());
 
-	nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &bs_revoke_and_ack);
+	nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &cs_revoke_and_ack);
 	check_added_monitors!(nodes[1], 1);
-	nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &bs_commitment_signed);
+	nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &cs_commitment_signed);
 	check_added_monitors!(nodes[1], 1);
-	let as_final_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
+	let bs_final_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
 
-	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &as_final_raa);
+	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &bs_final_raa);
 	check_added_monitors!(nodes[2], 1);
 
 	expect_pending_htlcs_forwardable!(nodes[2]);
@@ -2091,11 +2091,11 @@ pub fn test_channel_reserve_holding_cell_htlcs() {
 	let commitment_update_2 = get_htlc_update_msgs!(nodes[0], nodes[1].node.get_our_node_id());
 
 	nodes[0].node.handle_commitment_signed_batch_test(nodes[1].node.get_our_node_id(), &as_commitment_signed);
-	let bs_revoke_and_ack = get_event_msg!(nodes[0], MessageSendEvent::SendRevokeAndACK, nodes[1].node.get_our_node_id());
+	let as_revoke_and_ack = get_event_msg!(nodes[0], MessageSendEvent::SendRevokeAndACK, nodes[1].node.get_our_node_id());
 	// No commitment_signed so get_event_msg's assert(len == 1) passes
 	check_added_monitors!(nodes[0], 1);
 
-	nodes[1].node.handle_revoke_and_ack(nodes[0].node.get_our_node_id(), &bs_revoke_and_ack);
+	nodes[1].node.handle_revoke_and_ack(nodes[0].node.get_our_node_id(), &as_revoke_and_ack);
 	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
 	check_added_monitors!(nodes[1], 1);
 

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -12036,8 +12036,8 @@ pub fn test_funding_signed_event() {
 	mine_transaction(&nodes[0], &tx);
 	mine_transaction(&nodes[1], &tx);
 
-	let as_channel_ready = get_event_msg!(nodes[1], MessageSendEvent::SendChannelReady, nodes[0].node.get_our_node_id());
-	nodes[1].node.handle_channel_ready(nodes[0].node.get_our_node_id(), &as_channel_ready);
+	let bs_channel_ready = get_event_msg!(nodes[1], MessageSendEvent::SendChannelReady, nodes[0].node.get_our_node_id());
+	nodes[1].node.handle_channel_ready(nodes[0].node.get_our_node_id(), &bs_channel_ready);
 	let as_channel_ready = get_event_msg!(nodes[0], MessageSendEvent::SendChannelReady, nodes[1].node.get_our_node_id());
 	nodes[0].node.handle_channel_ready(nodes[1].node.get_our_node_id(), &as_channel_ready);
 

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -3616,7 +3616,7 @@ pub fn test_simple_commitment_revoked_fail_backward() {
 	}
 }
 
-fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_bs_raa: bool, use_dust: bool, no_to_remote: bool) {
+fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_raa_to_b: bool, use_dust: bool, no_to_remote: bool) {
 	// Test that if our counterparty broadcasts a revoked commitment transaction we fail all
 	// pending HTLCs on that channel backwards even if the HTLCs aren't present in our latest
 	// commitment transaction anymore.
@@ -3662,50 +3662,50 @@ fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_bs_raa: bool, use
 	nodes[2].node.fail_htlc_backwards(&first_payment_hash);
 	expect_pending_htlcs_forwardable_and_htlc_handling_failed!(nodes[2], vec![HTLCHandlingFailureType::Receive { payment_hash: first_payment_hash }]);
 	check_added_monitors!(nodes[2], 1);
-	let updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
-	assert!(updates.update_add_htlcs.is_empty());
-	assert!(updates.update_fulfill_htlcs.is_empty());
-	assert!(updates.update_fail_malformed_htlcs.is_empty());
-	assert_eq!(updates.update_fail_htlcs.len(), 1);
-	assert!(updates.update_fee.is_none());
-	nodes[1].node.handle_update_fail_htlc(nodes[2].node.get_our_node_id(), &updates.update_fail_htlcs[0]);
-	let bs_raa = commitment_signed_dance!(nodes[1], nodes[2], updates.commitment_signed, false, true, false, true);
+	let cs_updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+	assert!(cs_updates.update_add_htlcs.is_empty());
+	assert!(cs_updates.update_fulfill_htlcs.is_empty());
+	assert!(cs_updates.update_fail_malformed_htlcs.is_empty());
+	assert_eq!(cs_updates.update_fail_htlcs.len(), 1);
+	assert!(cs_updates.update_fee.is_none());
+	nodes[1].node.handle_update_fail_htlc(nodes[2].node.get_our_node_id(), &cs_updates.update_fail_htlcs[0]);
+	let cs_raa = commitment_signed_dance!(nodes[1], nodes[2], cs_updates.commitment_signed, false, true, false, true);
 	// Drop the last RAA from 3 -> 2
 
 	nodes[2].node.fail_htlc_backwards(&second_payment_hash);
 	expect_pending_htlcs_forwardable_and_htlc_handling_failed!(nodes[2], vec![HTLCHandlingFailureType::Receive { payment_hash: second_payment_hash }]);
 	check_added_monitors!(nodes[2], 1);
-	let updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
-	assert!(updates.update_add_htlcs.is_empty());
-	assert!(updates.update_fulfill_htlcs.is_empty());
-	assert!(updates.update_fail_malformed_htlcs.is_empty());
-	assert_eq!(updates.update_fail_htlcs.len(), 1);
-	assert!(updates.update_fee.is_none());
-	nodes[1].node.handle_update_fail_htlc(nodes[2].node.get_our_node_id(), &updates.update_fail_htlcs[0]);
-	nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &updates.commitment_signed);
+	let cs_updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+	assert!(cs_updates.update_add_htlcs.is_empty());
+	assert!(cs_updates.update_fulfill_htlcs.is_empty());
+	assert!(cs_updates.update_fail_malformed_htlcs.is_empty());
+	assert_eq!(cs_updates.update_fail_htlcs.len(), 1);
+	assert!(cs_updates.update_fee.is_none());
+	nodes[1].node.handle_update_fail_htlc(nodes[2].node.get_our_node_id(), &cs_updates.update_fail_htlcs[0]);
+	nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &cs_updates.commitment_signed);
 	check_added_monitors!(nodes[1], 1);
 	// Note that nodes[1] is in AwaitingRAA, so won't send a CS
-	let as_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
-	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &as_raa);
+	let bs_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
+	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &bs_raa);
 	check_added_monitors!(nodes[2], 1);
 
 	nodes[2].node.fail_htlc_backwards(&third_payment_hash);
 	expect_pending_htlcs_forwardable_and_htlc_handling_failed!(nodes[2], vec![HTLCHandlingFailureType::Receive { payment_hash: third_payment_hash }]);
 	check_added_monitors!(nodes[2], 1);
-	let updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
-	assert!(updates.update_add_htlcs.is_empty());
-	assert!(updates.update_fulfill_htlcs.is_empty());
-	assert!(updates.update_fail_malformed_htlcs.is_empty());
-	assert_eq!(updates.update_fail_htlcs.len(), 1);
-	assert!(updates.update_fee.is_none());
-	nodes[1].node.handle_update_fail_htlc(nodes[2].node.get_our_node_id(), &updates.update_fail_htlcs[0]);
+	let cs_updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
+	assert!(cs_updates.update_add_htlcs.is_empty());
+	assert!(cs_updates.update_fulfill_htlcs.is_empty());
+	assert!(cs_updates.update_fail_malformed_htlcs.is_empty());
+	assert_eq!(cs_updates.update_fail_htlcs.len(), 1);
+	assert!(cs_updates.update_fee.is_none());
+	nodes[1].node.handle_update_fail_htlc(nodes[2].node.get_our_node_id(), &cs_updates.update_fail_htlcs[0]);
 	// At this point first_payment_hash has dropped out of the latest two commitment
 	// transactions that nodes[1] is tracking...
-	nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &updates.commitment_signed);
+	nodes[1].node.handle_commitment_signed_batch_test(nodes[2].node.get_our_node_id(), &cs_updates.commitment_signed);
 	check_added_monitors!(nodes[1], 1);
 	// Note that nodes[1] is (still) in AwaitingRAA, so won't send a CS
-	let as_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
-	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &as_raa);
+	let bs_raa = get_event_msg!(nodes[1], MessageSendEvent::SendRevokeAndACK, nodes[2].node.get_our_node_id());
+	nodes[2].node.handle_revoke_and_ack(nodes[1].node.get_our_node_id(), &bs_raa);
 	check_added_monitors!(nodes[2], 1);
 
 	// Add a fourth HTLC, this one will get sequestered away in nodes[1]'s holding cell waiting
@@ -3717,8 +3717,8 @@ fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_bs_raa: bool, use
 	assert!(nodes[1].node.get_and_clear_pending_events().is_empty());
 	check_added_monitors!(nodes[1], 0);
 
-	if deliver_bs_raa {
-		nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &bs_raa);
+	if deliver_raa_to_b {
+		nodes[1].node.handle_revoke_and_ack(nodes[2].node.get_our_node_id(), &cs_raa);
 		// One monitor for the new revocation preimage, no second on as we won't generate a new
 		// commitment transaction for nodes[0] until process_pending_htlc_forwards().
 		check_added_monitors!(nodes[1], 1);
@@ -3744,7 +3744,7 @@ fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_bs_raa: bool, use
 	connect_blocks(&nodes[1], ANTI_REORG_DELAY - 1);
 
 	let events = nodes[1].node.get_and_clear_pending_events();
-	assert_eq!(events.len(), if deliver_bs_raa { 3 + nodes.len() - 1 } else { 4 + nodes.len() });
+	assert_eq!(events.len(), if deliver_raa_to_b { 3 + nodes.len() - 1 } else { 4 + nodes.len() });
 	assert!(events.iter().any(|ev| matches!(
 		ev,
 		Event::ChannelClosed { reason: ClosureReason::CommitmentTxConfirmed, .. }
@@ -3762,9 +3762,9 @@ fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_bs_raa: bool, use
 	check_added_monitors!(nodes[1], 1);
 
 	let mut events = nodes[1].node.get_and_clear_pending_msg_events();
-	assert_eq!(events.len(), if deliver_bs_raa { 4 } else { 3 });
+	assert_eq!(events.len(), if deliver_raa_to_b { 4 } else { 3 });
 
-	if deliver_bs_raa {
+	if deliver_raa_to_b {
 		let nodes_2_event = remove_first_msg_event_to_node(&nodes[2].node.get_our_node_id(), &mut events);
 		match nodes_2_event {
 			MessageSendEvent::UpdateHTLCs { ref node_id, channel_id: _, updates: msgs::CommitmentUpdate { ref update_add_htlcs, ref update_fail_htlcs, ref update_fulfill_htlcs, ref update_fail_malformed_htlcs, .. } } => {
@@ -3809,7 +3809,7 @@ fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_bs_raa: bool, use
 					assert!(failed_htlcs.insert(payment_hash.0));
 					// If we delivered B's RAA we got an unknown preimage error, not something
 					// that we should update our routing table for.
-					if !deliver_bs_raa {
+					if !deliver_raa_to_b {
 						if let PathFailure::OnPath { network_update: Some(_) } = failure { } else { panic!("Unexpected path failure") }
 					}
 				},

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -8569,8 +8569,8 @@ pub fn test_manually_accept_inbound_channel_request() {
 	mine_transaction(&nodes[0], &tx);
 	mine_transaction(&nodes[1], &tx);
 
-	let as_channel_ready = get_event_msg!(nodes[1], MessageSendEvent::SendChannelReady, nodes[0].node.get_our_node_id());
-	nodes[1].node.handle_channel_ready(nodes[0].node.get_our_node_id(), &as_channel_ready);
+	let bs_channel_ready = get_event_msg!(nodes[1], MessageSendEvent::SendChannelReady, nodes[0].node.get_our_node_id());
+	nodes[1].node.handle_channel_ready(nodes[0].node.get_our_node_id(), &bs_channel_ready);
 	let as_channel_ready = get_event_msg!(nodes[0], MessageSendEvent::SendChannelReady, nodes[1].node.get_our_node_id());
 	nodes[0].node.handle_channel_ready(nodes[1].node.get_our_node_id(), &as_channel_ready);
 


### PR DESCRIPTION
```
git grep -P 'as_.*\s*=\s*get_event_msg!\(nodes\[(?!0\d*\])'
git grep -P 'bs_.*\s*=\s*get_event_msg!\(nodes\[(?!1\d*\])'
git grep -P 'cs_.*\s*=\s*get_event_msg!\(nodes\[(?!2\d*\])'
git grep -P 'ds_.*\s*=\s*get_event_msg!\(nodes\[(?!3\d*\])'
```

